### PR TITLE
fix(ci): remove auto-merge and add dependency audit gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
           node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files
+      - name: Audit bundled dependencies
+        run: npx audit-ci --critical --report-type summary
       - name: build
         run: npx projen build
       - name: Find mutations

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -27,6 +27,8 @@ jobs:
           node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
+      - name: Audit bundled dependencies
+        run: npx audit-ci --critical --report-type summary
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations
@@ -103,8 +105,3 @@ jobs:
           author: github-actions <github-actions@github.com>
           committer: github-actions <github-actions@github.com>
           signoff: true
-      - name: Enable auto-merge
-        if: steps.create-pr.outputs.pull-request-number != ''
-        run: gh pr merge --auto --squash "${{ steps.create-pr.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Summary

- Remove the "Enable auto-merge" step from the `upgrade-main` workflow. Auto-merging dependency upgrade PRs is a supply chain risk — a compromised or malicious package update could be merged without human review.
- Add an `audit-ci` step (critical-severity gate) to both the `upgrade-main` and `build` workflows, running after dependency installation. This ensures that any dependency with a known critical vulnerability will fail the workflow before the PR can be merged.

## Changes

- `.github/workflows/upgrade-main.yml`: Removed the `gh pr merge --auto --squash` step; added "Audit bundled dependencies" step after "Install dependencies".
- `.github/workflows/build.yml`: Added "Audit bundled dependencies" step after "Install dependencies".

## Test plan

- [ ] Verify the `upgrade-main` workflow no longer auto-merges PRs
- [ ] Verify `audit-ci` step runs successfully in both workflows when no critical vulnerabilities exist
- [ ] Verify `audit-ci` step fails the workflow when a critical vulnerability is present