### PR TITLE
fix(ci): use exact ref match in release tag check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         id: check_tag_exists
         run: |-
           TAG=$(cat dist/releasetag.txt)
-          ([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin $TAG && (echo "exists=true" >> $GITHUB_OUTPUT)) || (echo "exists=false" >> $GITHUB_OUTPUT)
+          ([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin "refs/tags/$TAG" && (echo "exists=true" >> $GITHUB_OUTPUT)) || (echo "exists=false" >> $GITHUB_OUTPUT)
           cat $GITHUB_OUTPUT
       - name: Check for new commits
         id: git_remote

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -261,6 +261,14 @@ releaseWorkflow.file!.addOverride('on.push.paths-ignore', [
   'cdkamibuilder/**',
 ]);
 
+// Fix tag existence check to use exact ref match (prevents Go module tags like
+// cdkamibuilder/v0.0.190 from falsely matching when checking for v0.0.190)
+releaseWorkflow.file!.addOverride('jobs.release.steps.5.run', [
+  'TAG=$(cat dist/releasetag.txt)',
+  '([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin "refs/tags/$TAG" && (echo "exists=true" >> $GITHUB_OUTPUT)) || (echo "exists=false" >> $GITHUB_OUTPUT)',
+  'cat $GITHUB_OUTPUT',
+].join('\n'));
+
 // Dependency review on PRs — blocks merge if new high/critical vulnerabilities are introduced
 // Works with existing Dependabot security updates to create a merge gate
 const securityWorkflow = project.github!.addWorkflow('security');


### PR DESCRIPTION
## Summary

- Fixes the release workflow's tag existence check to use `refs/tags/$TAG` instead of bare `$TAG`
- `git ls-remote --tags origin v0.0.190` was suffix-matching the Go module tag `cdkamibuilder/v0.0.190`, causing all publish jobs to skip even though the main `v0.0.190` tag didn't exist
- v0.0.190 was never published to npm, PyPI, NuGet, or GitHub Releases due to this bug

## Root cause

When Go modules are published, publib creates tags like `cdkamibuilder/v0.0.190`. The release workflow's tag check (`git ls-remote --tags origin $TAG`) does suffix matching, so `v0.0.190` matches `cdkamibuilder/v0.0.190` and incorrectly reports the tag as existing.

## Verification

```bash
# Before fix (suffix match - incorrectly finds Go module tag)
$ git ls-remote -q --exit-code --tags origin v0.0.190
48ecaff...  refs/tags/cdkamibuilder/v0.0.190
# exit: 0

# After fix (exact match - correctly reports not found)
$ git ls-remote -q --exit-code --tags origin "refs/tags/v0.0.190"
# exit: 2

# Existing tags still match correctly
$ git ls-remote -q --exit-code --tags origin "refs/tags/v0.0.189"
53bb4e3...  refs/tags/v0.0.189
# exit: 0
```

## Test plan

- [x] Verified exact ref match correctly distinguishes Go module tags from release tags
- [x] `npx projen build` passes with no mutations
- [ ] CI build passes
- [ ] Release workflow correctly detects v0.0.190 as unpublished and runs publish jobs